### PR TITLE
Use only vitePreprocess

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,4 +1,3 @@
-import preprocess from 'svelte-preprocess'
 import adapter from '@sveltejs/adapter-auto'
 import { vitePreprocess } from '@sveltejs/kit/vite'
 
@@ -7,10 +6,7 @@ const config = {
 	// Consult https://kit.svelte.dev/docs/integrations#preprocessors
 	// for more information about preprocessors
 	preprocess: [
-		vitePreprocess(),
-		preprocess({
-			postcss: true,
-		}),
+		vitePreprocess()
 	],
 
 	kit: {


### PR DESCRIPTION
vitePreprocess already handles postcss, so it shouldn't be necessary to have both preprocessors in there.  More info at https://kit.svelte.dev/docs/integrations#preprocessors

But if you did mean to have this setup, I'd love to know why as it would impact how I set things up in the Skeleton CLI.