### PR TITLE
Fix: Provides correct types for `user` in the page store

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -2,21 +2,23 @@
 // for information about these interfaces
 
 /// <reference types="lucia-auth" />
-declare namespace Lucia {
-	type Auth = import('$lib/server/auth').Auth
-	type UserAttributes = {
-		username: string
-	}
-}
-
 declare global {
 	namespace App {
 		// interface Error {}
 		interface Locals {
 			auth: import('lucia-auth').AuthRequest
 		}
-		// interface PageData {}
+		interface PageData {
+			user: import('lucia-auth').User
+		}
 		// interface Platform {}
+	}
+
+	namespace Lucia {
+		type Auth = import('$lib/server/auth').Auth
+		type UserAttributes = {
+			username: string
+		}
 	}
 }
 

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,4 +1,4 @@
-/** @type {import('./$types').PageServerLoad} */
 export async function load({ locals }) {
-	return locals.auth.validateUser()
+	const { user } = await locals.auth.validateUser()
+	return { user }
 }


### PR DESCRIPTION
Small config change to fix the types for the `user` object from `validateUser()`. Previously, the type for `user` would return as type `any`.